### PR TITLE
feat: generate dnsNames from jx-requirements ingress + environments config

### DIFF
--- a/charts/acme/templates/_helpers.tpl
+++ b/charts/acme/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a list of domains from the environments list and default ingress domain
+*/}}
+{{- define "acme.dnsNamesStaging" -}}
+{{- $domains := list .Values.jxRequirements.ingress.domain }}
+{{- range $environmentConfig := .Values.jxRequirements.environments -}}
+{{- $tlsConfig := dig "ingress" "tls" dict $environmentConfig }}
+{{- if $tlsConfig.enabled | and (not $tlsConfig.production) }}
+{{- $domains = append $domains $environmentConfig.ingress.domain | mustUniq }}
+{{- end }}
+{{- end }}
+{{- range $dnsName := $domains }}
+- "*.{{ $dnsName }}"
+- "{{ $dnsName }}"
+{{- end }}
+{{- end }}
+
+{{- define "acme.dnsNamesProduction" -}}
+{{- $domains := list .Values.jxRequirements.ingress.domain }}
+{{- range $environmentConfig := .Values.jxRequirements.environments -}}
+{{- $tlsConfig := dig "ingress" "tls" dict $environmentConfig }}
+{{- if $tlsConfig.enabled | and $tlsConfig.production }}
+{{- $domains = append $domains $environmentConfig.ingress.domain | mustUniq }}
+{{- end }}
+{{- end }}
+{{- range $dnsName := $domains }}
+- "*.{{ $dnsName }}"
+- "{{ $dnsName }}"
+{{- end }}
+{{- end }}

--- a/charts/acme/templates/cert-manager-prod-certificate.yaml
+++ b/charts/acme/templates/cert-manager-prod-certificate.yaml
@@ -15,7 +15,6 @@ spec:
 {{- end }}
   commonName: "*.{{ .Values.jxRequirements.ingress.domain }}"
   dnsNames:
-  - "*.{{ .Values.jxRequirements.ingress.domain }}"
-  - "{{ .Values.jxRequirements.ingress.domain }}"
+{{- include "acme.dnsNamesProduction" . | trim | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
@@ -16,8 +16,7 @@ spec:
     solvers:
     - selector:
         dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
-        - "{{ .Values.jxRequirements.ingress.domain }}"
+{{- include "acme.dnsNamesProduction" . | trim | nindent 10 }}
       # ACME DNS-01 provider configurations
       dns01:
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}

--- a/charts/acme/templates/cert-manager-prod-issuer.yaml
+++ b/charts/acme/templates/cert-manager-prod-issuer.yaml
@@ -16,8 +16,7 @@ spec:
     solvers:
     - selector:
         dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
-        - "{{ .Values.jxRequirements.ingress.domain }}"
+{{- include "acme.dnsNamesProduction" . | trim | nindent 10 }}
       # ACME DNS-01 provider configurations
       dns01:
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}

--- a/charts/acme/templates/cert-manager-staging-certificate.yaml
+++ b/charts/acme/templates/cert-manager-staging-certificate.yaml
@@ -15,7 +15,6 @@ spec:
 {{- end }}
   commonName: "*.{{ .Values.jxRequirements.ingress.domain }}"
   dnsNames:
-  - "*.{{ .Values.jxRequirements.ingress.domain }}"
-  - "{{ .Values.jxRequirements.ingress.domain }}"
+{{- include "acme.dnsNamesStaging" . | trim | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
@@ -17,8 +17,7 @@ spec:
     solvers:
     - selector:
         dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
-        - "{{ .Values.jxRequirements.ingress.domain }}"
+{{- include "acme.dnsNamesStaging" . | trim | nindent 10 }}
       # ACME DNS-01 provider configurations
       dns01:
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}

--- a/charts/acme/templates/cert-manager-staging-issuer.yaml
+++ b/charts/acme/templates/cert-manager-staging-issuer.yaml
@@ -17,8 +17,7 @@ spec:
     solvers:
     - selector:
         dnsNames:
-        - "*.{{ .Values.jxRequirements.ingress.domain }}"
-        - "{{ .Values.jxRequirements.ingress.domain }}"
+{{- include "acme.dnsNamesStaging" . | trim | nindent 10 }}
       # ACME DNS-01 provider configurations
       dns01:
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}


### PR DESCRIPTION
imo, this jx-requirements.yaml file should generate a cert that's compatible with `staging.myorg.com` and `int.myorg.com`
```yaml
  environments:
  - key: dev
    owner: myorg-operations
    repository: jenkins-x-cluster
  - ingress:
      domain: staging.myorg.com
      externalDNS: true
      namespaceSubDomain: .
      tls:
        email: devops@myorg.com
        enabled: true
        production: true
    key: staging
    namespace: staging
  ingress:
    domain: int.myorg.com
    externalDNS: true
    kind: ingress
    namespaceSubDomain: -jx.
    tls:
      email: devops@myorg.com
      enabled: true
      production: true
```
i probably need tests if this is the accepted solution