### PR TITLE
fix: incorrect spelling preferedChain --> preferredChain

### DIFF
--- a/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
@@ -12,7 +12,7 @@ spec:
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-prod
-    preferedChain: "{{ .Values.issuer.preferredChain }}"
+    preferredChain: "{{ .Values.issuer.preferredChain }}"
     solvers:
     - selector:
         dnsNames:

--- a/charts/acme/templates/cert-manager-prod-issuer.yaml
+++ b/charts/acme/templates/cert-manager-prod-issuer.yaml
@@ -9,7 +9,7 @@ spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
     email: "{{ .Values.jxRequirements.ingress.tls.email }}"
-    preferedChain: "{{ .Values.issuer.preferredChain }}"
+    preferredChain: "{{ .Values.issuer.preferredChain }}"
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-prod

--- a/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
@@ -10,7 +10,7 @@ spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     email: "{{ .Values.jxRequirements.ingress.tls.email }}"
-    preferedChain: "{{ .Values.issuer.preferredChain }}"
+    preferredChain: "{{ .Values.issuer.preferredChain }}"
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-staging

--- a/charts/acme/templates/cert-manager-staging-issuer.yaml
+++ b/charts/acme/templates/cert-manager-staging-issuer.yaml
@@ -10,7 +10,7 @@ spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     email: "{{ .Values.jxRequirements.ingress.tls.email }}"
-    preferedChain: "{{ .Values.issuer.preferredChain }}"
+    preferredChain: "{{ .Values.issuer.preferredChain }}"
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-staging


### PR DESCRIPTION
version 0.0.25 is getting the following error:
```
unknown field "preferedChain" in io.cert-manager.v1.ClusterIssuer.spec.acme;
```