### PR TITLE
feat: use a explicit managed identity for azureDNS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,4 @@
 approvers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ccojocar
-- garethjevans
-- pmuir
-- abayer
+- maintainers
 reviewers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ccojocar
-- garethjevans
-- pmuir
-- abayer
+- maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,3 @@
+foreignAliases:
+- name: jx-community
+  org: jenkins-x

--- a/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-prod-clusterissuer.yaml
@@ -40,6 +40,8 @@ spec:
           subscriptionID: {{ .Values.jxRequirements.cluster.azure.dns.subscriptionId }}
           resourceGroupName: {{ .Values.jxRequirements.cluster.azure.dns.resourceGroup }}
           hostedZoneName: {{ .Values.jxRequirements.ingress.domain }}
+          managedIdentity:
+            clientID: {{ .Values.jxRequirements.cluster.azure.clusterNodes.clientID }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/acme/templates/cert-manager-prod-issuer.yaml
+++ b/charts/acme/templates/cert-manager-prod-issuer.yaml
@@ -40,6 +40,8 @@ spec:
           subscriptionID: {{ .Values.jxRequirements.cluster.azure.dns.subscriptionId }}
           resourceGroupName: {{ .Values.jxRequirements.cluster.azure.dns.resourceGroup }}
           hostedZoneName: {{ .Values.jxRequirements.ingress.domain }}
+          managedIdentity:
+            clientID: {{ .Values.jxRequirements.cluster.azure.clusterNodes.clientID }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
+++ b/charts/acme/templates/cert-manager-staging-clusterissuer.yaml
@@ -41,6 +41,8 @@ spec:
           subscriptionID: {{ .Values.jxRequirements.cluster.azure.dns.subscriptionId }}
           resourceGroupName: {{ .Values.jxRequirements.cluster.azure.dns.resourceGroup }}
           hostedZoneName: {{ .Values.jxRequirements.ingress.domain }}
+          managedIdentity:
+            clientID: {{ .Values.jxRequirements.cluster.azure.clusterNodes.clientID }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/acme/templates/cert-manager-staging-issuer.yaml
+++ b/charts/acme/templates/cert-manager-staging-issuer.yaml
@@ -41,6 +41,8 @@ spec:
           subscriptionID: {{ .Values.jxRequirements.cluster.azure.dns.subscriptionId }}
           resourceGroupName: {{ .Values.jxRequirements.cluster.azure.dns.resourceGroup }}
           hostedZoneName: {{ .Values.jxRequirements.ingress.domain }}
+          managedIdentity:
+            clientID: {{ .Values.jxRequirements.cluster.azure.clusterNodes.clientID }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Explicitly set the client id of the managed identity that the solver should use. Fixes errors where multiple service principals are found on the node pool.

Setup as outlined in the [docs](https://cert-manager.io/docs/configuration/acme/dns01/azuredns/#configure-a-clusterissuer)